### PR TITLE
Fix default persistance settings

### DIFF
--- a/linkwarden/templates/deployment.yaml
+++ b/linkwarden/templates/deployment.yaml
@@ -68,13 +68,13 @@ spec:
             {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.configuration.storageFolder }}
+              subPath: data
             {{- end }}
       volumes:
         {{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "linkwarden.fullname" . }}-pvc
-            subPath: data
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/linkwarden/templates/deployment.yaml
+++ b/linkwarden/templates/deployment.yaml
@@ -68,7 +68,6 @@ spec:
             {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.configuration.storageFolder }}
-              subPath: data
             {{- end }}
       volumes:
         {{- if .Values.persistence.enabled }}

--- a/linkwarden/templates/deployment.yaml
+++ b/linkwarden/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: data
-              mountPath: {{ .Values.configuration.storageFolder }}
+              mountPath: "/data/{{ .Values.configuration.storageFolder }}"
             {{- end }}
       volumes:
         {{- if .Values.persistence.enabled }}

--- a/linkwarden/templates/deployment.yaml
+++ b/linkwarden/templates/deployment.yaml
@@ -74,6 +74,7 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "linkwarden.fullname" . }}-pvc
+            subPath: data
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/linkwarden/values.yaml
+++ b/linkwarden/values.yaml
@@ -35,10 +35,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -53,7 +55,8 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts: []
@@ -85,7 +88,7 @@ persistence:
   size: "1Gi"
 
 configuration:
-  storageFolder: "/pfs"
+  storageFolder: "pfs"
   paginationTakeCount: ""
   autoscrollTimeout: ""
   publicDisableRegistration: ""


### PR DESCRIPTION
I noticed today that my linkwarden deployment wasn't actually persisting archival pdfs and whatnot.  Whenever the pod would restart the archived content would disappear.  During research I first found [this](https://github.com/linkwarden/linkwarden/issues/354) which indicates the STORAGE_FOLDER used in the configmap shouldn't include the prefix slash.  Unfortunately, the [`configuration.storageFolder` default in `values.yaml`](https://github.com/soubenz/linkwarden-helm-chart/blob/6654f9cd21de5a20c96f4c6878fd800963320d32/linkwarden/values.yaml#L88) is used for both [`STORAGE_FOLDER` in the configmap](https://github.com/soubenz/linkwarden-helm-chart/blob/6654f9cd21de5a20c96f4c6878fd800963320d32/linkwarden/templates/configmap.yaml#L11) as well as in the [volumeMount clause of the deployment yaml](https://github.com/soubenz/linkwarden-helm-chart/blob/6654f9cd21de5a20c96f4c6878fd800963320d32/linkwarden/templates/deployment.yaml#L70).

I was able to resolve this by:

- modifying the values.yaml to no longer include the prefix slash
- modifying `deployment.yaml` to prepend `.Values.configuration.storageFolder` with /data/

This puts the PVC mount at /data/pfs and sets STORAGE_FOLDER to pfs.  In my deployment this DOES fix things, though I had to delete my linkwarden-pvc and rebuild it.

To rebuild it, I was able to log in normally, open devtools console, and paste the following to requeue links 1-384.  Make sure you update the url domain to match your own implementation.  If you've deleted any links, you'll get an error when it hits that link number, but otherwise this works without issue in my cluster

```
(function() {
    for (let linkNum = 1; linkNum <= 384; linkNum++) {
        const url = `https://my.domain.com/api/v1/links/${linkNum}/archive`;
        
        fetch(url, {
            method: 'PUT',
            headers: {
                'Content-Type': 'application/json',
                // Add authorization or any other required headers here if needed
            },
        })
        .then(response => {
            if (response.ok) {
                console.log(`Successfully archived link #${linkNum}`);
            } else {
                console.error(`Failed to archive link #${linkNum}:`, response.statusText);
            }
        })
        .catch(error => {
            console.error(`Error archiving link #${linkNum}:`, error);
        });
    }
})();

```