### PR TITLE
PVC now properly gets disabled when persistence.enabled is false and secret can be disabled

### DIFF
--- a/linkwarden/templates/pvc.yaml
+++ b/linkwarden/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,3 +12,4 @@ spec:
     requests:
       storage: {{ .Values.persistence.size }}
   storageClassName: {{ .Values.persistence.storageClass }}
+{{- end }}

--- a/linkwarden/templates/secret.yaml
+++ b/linkwarden/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   {{- if .Values.configuration.authentication.authSecret }}
   authSecret: {{ .Values.configuration.authentication.authSecret | b64enc }}
   {{- end }}
+{{- end }}

--- a/linkwarden/values.yaml
+++ b/linkwarden/values.yaml
@@ -20,6 +20,9 @@ postgres:
     enabled: false
     uri: ""
 
+secret:
+  enabled: true
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ The following table lists the configurable parameters of the Linkwarden chart an
 | `postgres.database`                       | PostgreSQL database                                                         | `postgres`                                   |
 | `postgres.external.enabled`               | Enable external PostgreSQL                                                  | `false`                                      |
 | `postgres.external.uri`                   | External PostgreSQL URI                                                     | `""`                                         |
+| `secret.enabled`                          | Enable the auto-generated secret                                            | `true`                                       |
 | `serviceAccount.create`                   | Specifies whether a service account should be created                       | `true`                                       |
 | `serviceAccount.annotations`              | Annotations to add to the service account                                   | `{}`                                         |
 | `serviceAccount.name`                     | The name of the service account to use                                      | `""`                                         |


### PR DESCRIPTION
Thanks for this project, it's nice that most of the work was already done :smile:. Fixed a bug where the PVC was still being generated when persistence.enabled was false. And made the secret optional so a user could define their own. Helpful when using argocd for deployments.